### PR TITLE
Separate the commands and the output in the lighttpd example

### DIFF
--- a/lighttpd-example.md
+++ b/lighttpd-example.md
@@ -244,7 +244,7 @@ Due to limitations with Docker for Mac, we have separate instructions to demonst
 ```
 $ mayhem sync . 
 ```
-
+The output would be: 
 ```
 WARNING: downloading file with sha {sha256} project_slug {project_slug} owner {owner}
 Downloaded: Mayhemfile.
@@ -253,11 +253,11 @@ Extracting tests 14 of 14 |#####################################################
 Successfully downloaded coverage
 Target synced at: '.'.
 ```
-
+Now check the files in the directory
 ```
 $ ls 
 ```
-
+It would show: 
 ```
 block_coverage.drcov  defects  func_coverage.json  line_coverage.lcov  Mayhemfile  tests
 ```


### PR DESCRIPTION
Hi,

I had attended the hackathon today at ASU and while following the lighttpd example, I felt that the documentation would have been more beginner friendly had the commands and their outputs been separated. This would make it easier for the readers to follow and copy commands to their machine. I have made the changes. 

Apart from that, I have included a dollar '$' sign to the start of the commands so that users can differentiate it from the outputs.

Do let me know if you have any thoughts or want me to contribute more to the repository.

Regards,
Praveen Alex Mathew
Masters in Computer Science,
Arizona State University

https://praveenmathew92.github.io/